### PR TITLE
Add containerPort option to avoid using HTTPS port 443 for plain HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ If you would like to reference the VPC elsewhere (such as other clusters). The V
             //otherwise a random port will be attached to it
               //If not albProtocol is set, this port will not be attached to the ALB
             albProtocol?: "HTTP" | "HTTPS";
-            port?: number;
+            port?: number; // 443 for HTTPS
+            containerPort?: number; // Port of docker container, e.g. 8080
             //
             certificateArns?: string[]; // needed for https
             authorizer?: {

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you would like to reference the VPC elsewhere (such as other clusters). The V
               //If not albProtocol is set, this port will not be attached to the ALB
             albProtocol?: "HTTP" | "HTTPS";
             port?: number; // 443 for HTTPS
-            containerPort?: number; // Port of docker container, e.g. 8080
+            containerPort?: number; // If container port is different than the one exposed on the ALB, container port can be specified, e.g. 8080
             //
             certificateArns?: string[]; // needed for https
             authorizer?: {

--- a/src/options.ts
+++ b/src/options.ts
@@ -100,11 +100,13 @@ export type IServiceListener = {
     {
         albProtocol: "HTTP" | "HTTPS"; //dictitates if service will be attached to ALB or not
         port?: number; 
+        containerPort?: number;
     }
      |
     {
         albProtocol?: "HTTP" | "HTTPS"; //dictitates if service will be attached to ALB or not
         port: number;
+        containerPort?: number;
     }
 )
 

--- a/src/resources/protocol.ts
+++ b/src/resources/protocol.ts
@@ -14,11 +14,13 @@ export class Protocol extends Resource<IServiceListener> {
                        stage: string,
                        options: IServiceListener, 
                        port: number,
+                       containerPort: number,
                        tags?: object) {
         super(options, stage, service.getNamePrefix(), tags);
         this.cluster = cluster;
         this.service = service;
         this.port = port;
+        this.containerPort = containerPort;
     }
 
     /* Resource life-cycle */


### PR DESCRIPTION
I was confused by HTTPS port 443 being used also as `containerPort` with plain HTTP traffic.

Seeing that health checks fail trying to access my docker image via port 443, while it expects port 8080, lead me to adding `containerPort` option to this plugin copy to clearly have `port: 443` for HTTPS ALB listener and `containerPort: 8080` for HTTP in `TargetGroup` and ECS container, to see clear SSL unwrapping happening at ALB.

Later I discovered the true reason of health check failure was the issue https://github.com/Hybridless/serverless-ecs-plugin/issues/2 I reported, so please fix that issue first.

But to avoid further confusion of other users of this plugin regarding `HTTPS port != HTTP containerPort`, please also review and merge this PR
